### PR TITLE
Update gas file output to use alpha/eta SST values

### DIFF
--- a/PyBoltz/Boltz.pxd
+++ b/PyBoltz/Boltz.pxd
@@ -11,6 +11,8 @@ cdef class Boltz:
     cpdef Start(self)
 
     cdef public:
+        bint Crossed_SST
+        '''This is flag to mark if the steady state threshold has been crossed.'''
         double EFieldOverBField
         '''This is a constant that is equal to the electric field / magentic field * 1e-9.'''
         double AngularSpeedOfRotation

--- a/PyBoltz/Boltz.pyx
+++ b/PyBoltz/Boltz.pyx
@@ -193,6 +193,7 @@ cdef class Boltz:
         self.ReducedIonization = 0.0
         self.ReducedAttachment = 0.0
         self.Steady_State_Threshold = 40.0
+        self.Crossed_SST = False
         self.MixObject = Gasmix()
 
     def reset(self):
@@ -354,10 +355,13 @@ cdef class Boltz:
         self.end()
         # Steady state
         if abs(self.ReducedIonization - self.ReducedAttachment) >= self.Steady_State_Threshold:
-            if self.ReducedIonization ==0:
+            if self.ReducedIonization == 0:
                 print("Steady State Threshold has been crossed. Will not run the SST simulation as the ionisation rate is zero.")
                 return
-            if self.Console_Output_Flag: print("\n**Crossed the set Steady state simulation threshold = {}\n".format(self.Steady_State_Threshold))
+            if self.Console_Output_Flag:
+                print("\n**Crossed the set Steady state simulation threshold = {}\n".format(self.Steady_State_Threshold))
+
             TownsendFunc.run(self)
+            self.Crossed_SST = True
 
         return

--- a/PyBoltz/OdieRun.py
+++ b/PyBoltz/OdieRun.py
@@ -138,8 +138,12 @@ class OdieRun:
             [MBObject.ErrorDiffusionXZ, MBObject.ErrorDiffusionYZ, MBObject.ErrorDiffusionZ]
         ]
         Outputs['DTensor'] = PBRes(np.array(DTensor), np.array(DTensorErr))
+
         Outputs['AttachmentRate'] = PBRes(MBObject.AttachmentRate, MBObject.AttachmentRateError)
         Outputs['IonisationRate'] = PBRes(MBObject.IonisationRate, MBObject.IonisationRateError)
+        Outputs['AttachmentSST'] = PBRes(MBObject.AttachmentSST, MBObject.AttachmentSSTErr)
+        Outputs['IonisationSST'] = PBRes(MBObject.AlphaSST, MBObject.AlphaSSTErr)
+        Outputs['Crossed_SST'] = MBObject.Crossed_SST
 
         lor_angle, lor_error = self.CalcLorentzAngle(MBObject)
         Outputs['LorentzAngle'] = PBRes(lor_angle, lor_error)
@@ -427,9 +431,16 @@ class OdieRun:
                     dt = Output['DT1'].val * SQRTP * 1E-4
 
                     #Yes, alpha and alpha0 are supposed to be the same value.
-                    alpha = Output['IonisationRate'].val
+                    alpha  = Output['IonisationRate'].val
                     alpha0 = Output['IonisationRate'].val
-                    eta = Output['AttachmentRate'].val
+                    eta    = Output['AttachmentRate'].val
+
+                    #If the steady state threshold was crossed, use the SST calculation of the ionisation
+                    #and attachment coefficients as the default values.
+                    if Output['Crossed_SST'] is True:
+                        alpha  = Output['IonisationSST'].val
+                        alpha0 = Output['IonisationSST'].val
+                        eta    = Output['AttachmentSST'].val
 
                     #If the coefficients are zero, set to -30 as a sufficiently small power; log(-30) is basically zero.
                     #Otherwise store the logarithm of the reduced coefficients.


### PR DESCRIPTION
Updated OdieRun to use the alpha and eta SST calculation values in the
gas file when the steady state threshold is crossed.

Previously the gas file would always store the first calculation of
alpha and eta. These values can be quite different from the later
calculations of alpha and eta from the SST, PT, or TOF simulations.

MagBoltz by default reports the SST calculations of alpha and eta if the
steady state threshold has been crossed. OdieRun now does the same in
the gas file.

The Boltz class was modified to include a boolean flag to indicate if
the steady state threshold has been crossed.

NB: If the steady state threshold was crossed, but the SST simulation
was not run, the flag is set to False as the alpha and eta SST values
are not calculated.